### PR TITLE
Disable Prettier Pragma Rules and Documentation Updates

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,7 +1,7 @@
 {
 	"endOfLine": "lf",
 	"requirePragma": false,
-	"insertPragma": true,
+	"insertPragma": false,
 	"printWidth": 80,
 	"useTabs": true,
 	"tabWidth": 2,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,3 @@
-<!-- @format -->
-
 # Changelog
 
 All notable changes to this project will be documented in this file.
@@ -8,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Changed
+
+- Set `insertPragma` option in Prettier config file to `false`.
+- Removed JavaScript `/** @format */` comments from `.js` and `.ts` files.
+- Removed `<!-- @format -->` comments from documentation files.
+- Replaced remaining `console.log` statements with consistent logger utility in middleware files.
+- Updated project structure diagram in `README.md` to include `src/utils` directory.
 
 ## [0.1.2] - 2025-05-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Removed `<!-- @format -->` comments from documentation files.
 - Replaced remaining `console.log` statements with consistent logger utility in middleware files.
 - Updated project structure diagram in `README.md` to include `src/utils` directory.
+- Updated and expanded project badges in `README.md`.
 
 ## [0.1.2] - 2025-05-19
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,16 @@
-<!-- @format -->
-
 # CODStats API
 
-![GitHub License](https://img.shields.io/github/license/topfrag-gg/codstats-api?color=blue)
-![Version](https://img.shields.io/github/v/tag/topfrag-gg/codstats-api)
-![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/topfrag-gg/codstats-api/build.yml)
-![Contributors](https://img.shields.io/static/v1?label=contributors&message=1&color=purple)
+![License](https://img.shields.io/github/license/topfrag-gg/codstats-api?color=blue)
+![Version](https://img.shields.io/github/v/tag/topfrag-gg/codstats-api?label=version)
+![Build](https://img.shields.io/github/actions/workflow/status/topfrag-gg/codstats-api/build.yml)
+![Last Commit](https://img.shields.io/github/last-commit/topfrag-gg/codstats-api?color=blueviolet)
+![Top Language](https://img.shields.io/github/languages/top/topfrag-gg/codstats-api?color=2943d6)
+![Code Size](https://img.shields.io/github/languages/code-size/topfrag-gg/codstats-api?color=red)
 ![GitHub repo size](https://img.shields.io/github/repo-size/topfrag-gg/codstats-api?color=yellow)
-![GitHub code size](https://img.shields.io/github/languages/code-size/topfrag-gg/codstats-api?color=red)
 ![GitHub repo file or directory count](https://img.shields.io/github/directory-file-count/topfrag-gg/codstats-api?color=skyblue)
-![GitHub Repo stars](https://img.shields.io/github/stars/topfrag-gg/codstats-api)
+![Contributors](https://img.shields.io/github/contributors/topfrag-gg/codstats-api?color=5d00ff)
+![Open Issues](https://img.shields.io/github/issues/topfrag-gg/codstats-api?color=ff0000)
+![Stars](https://img.shields.io/github/stars/topfrag-gg/codstats-api)
 ![GitHub watchers](https://img.shields.io/github/watchers/topfrag-gg/codstats-api)
 
 ## Overview
@@ -44,6 +45,7 @@ codstats-api/
 │  ├─ libs/                   # Core express setup, CORS, helmet
 │  ├─ middleware/             # API middleware (error, redirect, 404)
 │  ├─ routes/                 # Route handlers (index, health, etc.)
+│  ├─ utils/                  # Utility functions and helpers (logger, etc.)
 │  ├─ app.ts                  # Express app instance
 │  ├─ server.ts               # Server bootstrap
 ├─ .dockerignore              # Files and folders to exclude from Docker build context

--- a/config/default.js
+++ b/config/default.js
@@ -1,5 +1,3 @@
-/** @format */
-
 import 'dotenv/config';
 import { readFileSync } from 'node:fs';
 import path from 'node:path';

--- a/config/production.js
+++ b/config/production.js
@@ -1,5 +1,3 @@
-/** @format */
-
 import 'dotenv/config';
 
 export default {

--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,3 @@
-/** @format */
-
 import { startServer } from '@/src/server';
 import 'dotenv/config';
 

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,5 +1,3 @@
-/** @format */
-
 import { execSync } from 'node:child_process';
 import console from 'node:console';
 

--- a/scripts/loader.js
+++ b/scripts/loader.js
@@ -1,5 +1,3 @@
-/** @format */
-
 import { pathToFileURL } from 'node:url';
 import { resolve as resolveTs } from 'ts-node/esm';
 import * as tsConfigPaths from 'tsconfig-paths';

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,5 +1,3 @@
-/** @format */
-
 import path from 'node:path';
 import process from 'node:process';
 import compression from 'compression';

--- a/src/libs/cors.ts
+++ b/src/libs/cors.ts
@@ -1,5 +1,3 @@
-/** @format */
-
 import { CorsOptions } from 'cors';
 
 // Allowed origins

--- a/src/libs/express.ts
+++ b/src/libs/express.ts
@@ -1,5 +1,3 @@
-/** @format */
-
 import config from 'config';
 import express, { Application } from 'express';
 

--- a/src/libs/helmet.ts
+++ b/src/libs/helmet.ts
@@ -1,5 +1,3 @@
-/** @format */
-
 import { type HelmetOptions } from 'helmet';
 
 export const helmetOptions = (options?: HelmetOptions): object => {

--- a/src/middleware/api-redirect.ts
+++ b/src/middleware/api-redirect.ts
@@ -1,5 +1,3 @@
-/** @format */
-
 import { NextFunction, Request, Response } from 'express';
 
 export const globalRedirect = (

--- a/src/middleware/error-handler.ts
+++ b/src/middleware/error-handler.ts
@@ -1,7 +1,5 @@
-/** @format */
-
-import console from 'node:console';
 import { Request, Response } from 'express';
+import { logger } from '../utils/logger';
 
 interface CustomError extends Error {
 	status?: number;
@@ -45,10 +43,10 @@ export const createErrorHandler = ({
 		};
 
 		//Log the error
-		console.error('Error:', err.message);
+		logger.error('Error:', err.message);
 
 		if (!isProduction) {
-			console.error('Stack:', err.stack);
+			logger.error('Stack:', err.stack);
 		}
 
 		// Send the error response

--- a/src/middleware/http-logger.ts
+++ b/src/middleware/http-logger.ts
@@ -1,5 +1,3 @@
-/** @format */
-
 import process from 'node:process';
 import chalk from 'chalk';
 import config from 'config';

--- a/src/middleware/not-found.ts
+++ b/src/middleware/not-found.ts
@@ -1,8 +1,6 @@
-/** @format */
-
-import console from 'node:console';
 import { NextFunction, Request, Response } from 'express';
 import createError from 'http-errors';
+import { logger } from '../utils/logger';
 
 type NotFoundHandlerDeps = {
 	isProduction: boolean;
@@ -27,7 +25,7 @@ export const createNotFoundHandler = ({
 		const errorMessage = `The requested resource '${req.originalUrl}' was not found`;
 
 		// Log the 404 warning
-		console.warn(`[404] ${req.method}: ${req.originalUrl}`);
+		logger.warn(`[404] ${req.method}: ${req.originalUrl}`);
 
 		// Send the 404 response
 		res.status(404).json({

--- a/src/routes/health.routes.ts
+++ b/src/routes/health.routes.ts
@@ -1,5 +1,3 @@
-/** @format */
-
 import { Request, Response, Router } from 'express';
 
 export const createHealthRouter = (): Router => {

--- a/src/routes/index.routes.ts
+++ b/src/routes/index.routes.ts
@@ -1,5 +1,3 @@
-/** @format */
-
 import { Application, Router } from 'express';
 import { createHealthRouter } from './health.routes';
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,5 +1,3 @@
-/** @format */
-
 import { exit } from 'node:process';
 import config from 'config';
 import { createApp } from './app';

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,5 +1,3 @@
-/** @format */
-
 import process from 'node:process';
 import util from 'node:util';
 import chalk from 'chalk';


### PR DESCRIPTION
### Summary

This PR focuses on maintaining code quality and improving documentation by cleaning up Prettier formatting directives, replacing legacy `console.log` statements, and enhancing the project’s README.

### Changed

- Disabled the `insertPragma` option in the Prettier configuration to prevent automatic insertion of format comments.
- Removed `/** @format */` comments from all applicable `.js` and `.ts` files.
- Removed `<!-- @format -->` comments from documentation files.

### Refactor

- Replaced remaining `console.log` statements in middleware (`error-handler.ts` and `not-found.ts`) with the custom logger utility for consistency and improved log structure.

### Documentation

- Updated the `README.md` project structure diagram to include the `src/utils` folder.
- Refreshed project badges with:
  - Better color contrast and readability
  - Additional metadata (e.g. top language, last commit, open issues)